### PR TITLE
[Red: Parser] Support Simple Insert Into Table

### DIFF
--- a/bridge/public/DbEntities.h
+++ b/bridge/public/DbEntities.h
@@ -8,6 +8,7 @@ struct Column {
   std::string dataType;
   bool bNullable = true; // default is nullable, unless specified as NOT NULL
   std::string comment;
+  // TODO: type should be expr instead of string
   std::string defaultExpr;
   std::size_t position;
   // std::string generationExpression;

--- a/light/public/SqlPlan.h
+++ b/light/public/SqlPlan.h
@@ -2,9 +2,11 @@
 
 #include "DbEntities.h"
 #include "TreeNode.h"
+#include <ctime>
 #include <memory>
 #include <numeric>
 #include <string>
+#include <variant>
 #include <vector>
 
 struct SqlContext; // Forward declaration
@@ -77,4 +79,44 @@ struct AddColumns : public TreeNode {
   bool nodeEquals(const TreeNode &other) const override;
   void run(const SqlContext *sqlCtx) const;
   std::shared_ptr<Identifier> tableName() const;
+};
+
+struct Query : public TreeNode {
+  std::string queryName;
+
+  // This is a placeholder for a query plan, which can be a SELECT, INSERT, etc.
+  // In a real implementation, this would contain more details about the query.
+  Query() {}
+  Query(const std::string &name) : queryName(name) {}
+
+  bool nodeEquals(const TreeNode &other) const;
+};
+
+struct Row {
+  std::vector<std::variant<int, long long, std::string, std::time_t>> values;
+};
+
+struct InlineTable : public Query {
+  std::vector<std::shared_ptr<Row>> rows;
+
+  InlineTable() : Query("InlineTable") {}
+
+  bool nodeEquals(const TreeNode &other) const override;
+};
+
+struct FunctionCall {
+  std::string functionName;
+
+  FunctionCall(const std::string &name) : functionName(name) {}
+};
+
+struct InsertInto : public TreeNode {
+  InsertInto();
+
+  bool nodeEquals(const TreeNode &other) const override;
+  void run(const SqlContext *sqlCtx) const;
+  std::shared_ptr<Identifier> tableName() const;
+  void setTableName(std::shared_ptr<Identifier> tableName);
+  std::shared_ptr<Query> query() const;
+  void setQuery(std::shared_ptr<Query> query);
 };

--- a/main.cpp
+++ b/main.cpp
@@ -25,8 +25,6 @@ int main(int , const char **) {
 
   SqlBaseParser parser(&tokens);
   SqlBaseParser::CompoundOrSingleStatementContext* parsed = parser.compoundOrSingleStatement();
-
-  std::cout << parsed->toStringTree() << std::endl;
   std::shared_ptr<CreateTable> plan = std::any_cast<std::shared_ptr<CreateTable>>(AstBuilder().visitCompoundOrSingleStatement(parsed));
   ResolveCatalogs r;
   r.init(&sqlCtx);
@@ -39,11 +37,17 @@ int main(int , const char **) {
   CommonTokenStream tokens2(&lexer2);
   SqlBaseParser parser2(&tokens2);
   SqlBaseParser::CompoundOrSingleStatementContext* parsed2 = parser2.compoundOrSingleStatement();
-  std::cout << parsed2->toStringTree() << std::endl;
   std::shared_ptr<AddColumns> plan2 = std::any_cast<std::shared_ptr<AddColumns>>(AstBuilder().visitCompoundOrSingleStatement(parsed2));
   auto result2 = plan2->resolveRulesDownWithPruning([](const TreeNode* n){ return false; }, &r);
   (std::dynamic_pointer_cast<AddColumns>(result2.afterRule))->run(&sqlCtx);
   assert(sqlCtx.currentCatalog()->getTable(sqlCtx.currentDatabaseName(), "my_tbl1")->schema.size() == 3);
+
+  ANTLRInputStream input3("INSERT INTO my_tbl1 VALUES (1, 'data1', '2023-10-01 12:00:00')");
+  SqlBaseLexer lexer3(&input3);
+  CommonTokenStream tokens3(&lexer3);
+  SqlBaseParser parser3(&tokens3);
+  SqlBaseParser::CompoundOrSingleStatementContext* parsed3 = parser3.compoundOrSingleStatement();
+  std::shared_ptr<InsertInto> plan3 = std::any_cast<std::shared_ptr<InsertInto>>(AstBuilder().visitCompoundOrSingleStatement(parsed3));
 
   return 0;
 }

--- a/red/public/AstBuilder.h
+++ b/red/public/AstBuilder.h
@@ -19,6 +19,15 @@ private:
     // std::vector<TableConstraint> tableConstraint;
   };
 
+  struct InsertTableParams {
+    std::vector<std::string> identifier;
+    // std::optional<SqlBaseParser::OptionsClauseContext *> options;
+    std::vector<std::string> userSpecifiedCols;
+    // std::map<std::string, std::optional<std::string>> partitionSpec;
+    bool ifPartitionNotExists;
+    bool byName;
+  };
+
   void stripSingleQuotes(std::string &s) const;
 
   void stripDoubleQuotes(std::string &s) const;


### PR DESCRIPTION
Change List:
1. Add `InsertInto` SqlPlan; Add `InlineTable` (derived from `Query`) to support parsing `InsertInto`
2. Implemented all the `visit` node in `AstBuilder` that parsing a `InsertInto` statement could touch
3. Define the return type of parsing literal expressions to be `std::variant`